### PR TITLE
CHECK-362 - Remove reliance on mfe-infrastructure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,8 +33,8 @@ runs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        role-to-assume: ${{ inputs.aws-role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
+        role-to-assume: ${{ inputs.aws-role-to-assume }}
 
     - run: aws sts get-caller-identity
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -33,8 +33,8 @@ runs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-region: ${{ inputs.aws-region }}
         role-to-assume: ${{ inputs.aws-role-to-assume }}
+        aws-region: ${{ inputs.aws-region }}
 
     - run: aws sts get-caller-identity
       shell: bash
@@ -62,6 +62,10 @@ runs:
         PUBLIC_STATIC_ASSETS_DIR="build/static-assets/public/"
 
         PUBLIC_STATIC_ASSETS_STAGING_DIR="../stage/"
+
+        GIT_HASH = ${{ env.GIT_SHA }}
+
+        APP_NAME = ${{ inputs.app-name }}
 
         mkdir -p $PUBLIC_STATIC_ASSETS_STAGING_DIR
 

--- a/action.yml
+++ b/action.yml
@@ -53,4 +53,29 @@ runs:
       env:
         GIT_SHA: ${{ steps.short-sha.outputs.sha }}
       shell: bash
-      run: ./mfe-infrastructure/ci/publish-static-assets.sh ${{ inputs.app-name }} ${{ env.GIT_SHA }}
+      run: |
+        STATIC_ASSETS_BUCKET=$(aws ssm get-parameters --names /checkout/dev/s3/static_assets_mfe/bucket_name --with-decryption --region ${{ inputs.aws-region }} | jq -r ".Parameters[0].Value")
+
+        CACHE_CONTROL_HEADER="public, max-age=31536000, immutable"
+
+        NEXTJS_STATIC_ASSETS_DIR="build/static-assets/next/static"
+        PUBLIC_STATIC_ASSETS_DIR="build/static-assets/public/"
+
+        PUBLIC_STATIC_ASSETS_STAGING_DIR="../stage/"
+
+        mkdir -p $PUBLIC_STATIC_ASSETS_STAGING_DIR
+
+        cp -r $PUBLIC_STATIC_ASSETS_DIR $PUBLIC_STATIC_ASSETS_STAGING_DIR
+
+        find $PUBLIC_STATIC_ASSETS_STAGING_DIR -type f -name "mockServiceWorker.js" -delete
+
+        echo "Uploading static assets for revision $GIT_HASH..."
+        echo "Checking for existing static assets for this revision..."
+
+        echo "Uploading Nextjs static assets directory to $STATIC_ASSETS_BUCKET/$APP_NAME/$GIT_HASH/_next/static.."
+        aws s3 cp $NEXTJS_STATIC_ASSETS_DIR s3://$STATIC_ASSETS_BUCKET/$APP_NAME/$GIT_HASH/_next/static --recursive --cache-control "$CACHE_CONTROL_HEADER"
+
+        echo "Uploading public files directory to $STATIC_ASSETS_BUCKET/$APP_NAME/$GIT_HASH/"
+        aws s3 cp $PUBLIC_STATIC_ASSETS_STAGING_DIR s3://$STATIC_ASSETS_BUCKET/$APP_NAME/$GIT_HASH/ --recursive --cache-control "$CACHE_CONTROL_HEADER"
+
+        echo "Static assets upload complete. See previous output for status."

--- a/action.yml
+++ b/action.yml
@@ -63,9 +63,9 @@ runs:
 
         PUBLIC_STATIC_ASSETS_STAGING_DIR="../stage/"
 
-        GIT_HASH = ${{ env.GIT_SHA }}
+        GIT_HASH = "${{ env.GIT_SHA }}"
 
-        APP_NAME = ${{ inputs.app-name }}
+        APP_NAME = "${{ inputs.app-name }}"
 
         mkdir -p $PUBLIC_STATIC_ASSETS_STAGING_DIR
 

--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,8 @@
-name: "Publish MFE static assets"
-description: "Publish MFE static assets"
+name: 'Publish MFE static assets'
+description: 'Publish MFE static assets'
 inputs:
-  aws-access-key-id:
-    description: 'AWS Access Key Id'
-    required: true
-
-  aws-secret-access-key:
-    description: 'AWS Secret Access Key'
+  aws-role-to-assume:
+    description: 'AWS IAM role to assume'
     required: true
 
   aws-region:
@@ -21,37 +17,38 @@ inputs:
     description: 'MFE app name (e.g. search-mfe)'
     required: true
 
-
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - uses: actions/checkout@v2
       with:
         token: ${{ inputs.submodules-pat }}
         submodules: 'true'
-        
+
     - uses: benjlevesque/short-sha@v1.2
       id: short-sha
       with:
         length: 7
-        
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        role-to-assume: ${{ inputs.aws-role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
-        
+
+    - run: aws sts get-caller-identity
+      shell: bash
+
     - uses: actions/download-artifact@v2
       with:
         name: next-static-assets
         path: build/static-assets/next
-        
+
     - uses: actions/download-artifact@v2
       with:
         name: public-static-assets
         path: build/static-assets/public
-      
+
     - name: publish static assets
       env:
         GIT_SHA: ${{ steps.short-sha.outputs.sha }}

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'MFE app name (e.g. search-mfe)'
     required: true
 
+  static-assets-bucket:
+    description: 'Name of the static assets bucket'
+    required: true
+
 runs:
   using: 'composite'
   steps:
@@ -54,7 +58,7 @@ runs:
         GIT_SHA: ${{ steps.short-sha.outputs.sha }}
       shell: bash
       run: |
-        STATIC_ASSETS_BUCKET=$(aws ssm get-parameters --names /checkout/dev/s3/static_assets_mfe/bucket_name --with-decryption --region ${{ inputs.aws-region }} | jq -r ".Parameters[0].Value")
+        STATIC_ASSETS_BUCKET="${{ inputs.static-assets-bucket }}"
 
         CACHE_CONTROL_HEADER="public, max-age=31536000, immutable"
 

--- a/action.yml
+++ b/action.yml
@@ -63,9 +63,9 @@ runs:
 
         PUBLIC_STATIC_ASSETS_STAGING_DIR="../stage/"
 
-        GIT_HASH = "${{ env.GIT_SHA }}"
+        GIT_HASH="${{ env.GIT_SHA }}"
 
-        APP_NAME = "${{ inputs.app-name }}"
+        APP_NAME="${{ inputs.app-name }}"
 
         mkdir -p $PUBLIC_STATIC_ASSETS_STAGING_DIR
 


### PR DESCRIPTION
Remove the reliance of the mfe-infrastructure repository so this action is self contained. Inline the `publish-static-assets.sh` script.

A major change in the script is to remove the step where the static asset bucket name is pulled from Parameter store and instead it is now an input to the action.

Also: move from AWS IAM users to IAM roles for AWS authentication.